### PR TITLE
Controller: moving getters to the prototype

### DIFF
--- a/Controller.js
+++ b/Controller.js
@@ -47,22 +47,17 @@ define([
       if ($view) {
         this._view.trigger('postrender', $view);
       }
-
-      Object.defineProperties(this, {
-        id: {
-          get: function() {
-            return this._model.id();
-          }
-        },
-        data: {
-          get: function() {
-            return this._model.data();
-          }
-        }
-      });
     }
   }, {
     VIEW_CLASS: View
   })
-  .mixin(log);
+  .mixin(log)
+  .mixin({
+    get id() {
+      return this._model.id();
+    },
+    get data() {
+      return this._model.data();
+    }
+  });
 });


### PR DESCRIPTION
This avoids `this.id` and `this.data` being set too late to be useful to overrides of `init`