### PR TITLE
Validate: Rules are optional unless declared required

### DIFF
--- a/test/specs/util/validate.js
+++ b/test/specs/util/validate.js
@@ -3,14 +3,9 @@ define(['util/validate'], function(validate) {
 
   var tests = {
 
-    required: {
-      good: [' ', 'anything', '!@#$%^&*()-=', '\''],
-      bad: ['', null, undefined]
-    },
-
     Generic: {
       good: [' ', 'anything', '!@#$%^&*()-=', '\''],
-      bad: ['<script type="jarvascript">document.write', '', null, undefined]
+      bad: ['<script type="jarvascript">document.write', null, undefined]
     },
 
     AlphaNumeric: {
@@ -59,11 +54,21 @@ define(['util/validate'], function(validate) {
     }
   },
 
+  /**
+   * Verify value for rules are valid. Context should be set to rules.
+   *
+   * @param {string} corpus value being validated
+   */
   good = function(corpus) {
     expect(validate(corpus, this)).toBe(true);
     expect(validate.message).not.toBeDefined();
   },
 
+  /**
+   * Verify value for rules are not valid. Context should be set to rules.
+   *
+   * @param {string} corpus value being validated
+   */
   bad = function(corpus) {
     expect(validate(corpus, this)).toBe(false);
     expect(validate.message).toBeDefined();
@@ -71,14 +76,33 @@ define(['util/validate'], function(validate) {
 
   describe('lib/validate', function() {
     var key;
-    function verify(key) {
+    function verifyRequired(key) {
+      var validator = 'required,' + key;
+      tests[key].good.forEach(good, validator);
+      tests[key].bad.forEach(bad, validator);
+    }
+
+    function verifyOptional(key) {
+      good.call(key, '');
+      bad.call(key, null);
+      bad.call(key, undefined);
+
       tests[key].good.forEach(good, key);
       tests[key].bad.forEach(bad, key);
     }
 
     for (key in tests) {
-      it('verifies ' + key, verify.bind(this, key));
+      it('verifies required ' + key, verifyRequired.bind(this, key));
     }
+
+    for (key in tests) {
+      it('verifies optional values correctly for ' + key, verifyOptional.bind(this, key));
+    }
+
+    it('verifies required', function() {
+      validate('', 'required,Generic');
+      expect(validate.message).toEqual('This field is required');
+    });
 
     it('verifies length', function() {
       var tests = {
@@ -86,8 +110,8 @@ define(['util/validate'], function(validate) {
         bad: ['', 'aaa']
       };
 
-      tests.good.forEach(good, "length[1,2]");
-      tests.bad.forEach(bad, "length[1,2]");
+      tests.good.forEach(good, "required,length[1,2]");
+      tests.bad.forEach(bad, "required,length[1,2]");
     });
 
     it('verifies optional', function() {

--- a/util/validate.js
+++ b/util/validate.js
@@ -214,21 +214,20 @@ define(function() {
   }
 
   function validate(body, rules) {
-    var optional;
+    if (typeof body !== 'string') {
+      validate.message = 'You must enter a value';
+      return false;
+    }
 
     delete validate.message;
     rules = rules ? commaSplit(rules) : [];
-    body = (body === null || body === undefined) ? '' : body;
 
-    optional = rules.indexOf('optional');
+    // When optional field with no value
+    if (rules.indexOf('required') === -1 && body === '') {
+      return true;
+    }
 
-    if (optional > -1) {
-      rules.splice(optional, optional + 1);
-      return !body || rules.every(check, body);
-    }
-    else {
-      return rules.every(check, body);
-    }
+    return rules.every(check, body);
   }
 
   // Per rule check
@@ -241,6 +240,7 @@ define(function() {
       meta = res[2];
     }
 
+    // Skip over invalid rule
     if (!(tests[rule] && tests[rule].test)) {
       return true;
     }


### PR DESCRIPTION
Before this PR the logic was like this:
```
validate( '', 'Generic'); // message about format being wrong
validate( '', 'required,Generic'); // message about being required
validate( '', 'optional,Generic'); // success
```

Both the code and users could infer that something is optional if it's not explicitly required.

The change in this PR ensures that no validators run if the fields are empty and not required. We should also consider marking `optional` as a deprecated "rule".

The behavior becomes:
```
validate( '', 'Generic'); // success
validate( '', 'required,Generic'); // message about being required
validate( '', 'optional,Generic'); // success
```