### PR TITLE
View/Dialog: guard against lack of event.originalEvent

### DIFF
--- a/View/Dialog.js
+++ b/View/Dialog.js
@@ -30,6 +30,8 @@ define([
       .on('click', '.js-disabled', false)
       // "annotate" the event
       .on('click touchend', function(e) {
+        // guard against no original event when called programmatically
+        e.originalEvent = e.originalEvent || {};
         e.originalEvent._view = this;
       }.bind(this));
     },


### PR DESCRIPTION
When a click event is called programmatically, the lack of originalEvent
causes an error.

Addresses issue #85