### PR TITLE
trait/eventMappable: fires event when method not found

### DIFF
--- a/test/specs/trait/eventMappable.js
+++ b/test/specs/trait/eventMappable.js
@@ -54,7 +54,7 @@ define(['trait/eventMappable', 'nbd/util/extend'], function(eventMappable, exten
 
       it('triggers events when method is not found', function() {
         test.events = {
-          click: 'trafalgar'
+          click: ':trafalgar'
         };
 
         test._mapEvents();

--- a/test/specs/trait/eventMappable.js
+++ b/test/specs/trait/eventMappable.js
@@ -11,134 +11,149 @@ define(['trait/eventMappable', 'nbd/util/extend'], function(eventMappable, exten
     div = test.$view[0];
   });
 
-  describe("_mapEvents", function() {
-    it('maps event correctly', function() {
-      expect(test.$view.is('div')).toBeTruthy();
-      test.events = {
-        click: 'trafalgar'
-      };
+  describe('trait/eventMappable', function() {
+    describe("_mapEvents", function() {
+      it('maps event correctly', function() {
+        expect(test.$view.is('div')).toBeTruthy();
+        test.events = {
+          click: 'trafalgar'
+        };
 
-      test.trafalgar = jasmine.createSpy();
-      test._mapEvents();
-      test.$view.click();
-      expect(test.trafalgar).toHaveBeenCalled();
-    });
-
-    it('does not trigger event that is not called', function() {
-      test.events = {
-        click: {
-          '.foo': 'trafalgar'
-        },
-        select: {
-          '.foo': 'bar'
-        }
-      };
-
-      test.trafalgar = jasmine.createSpy('trafalgar');
-      test.bar = jasmine.createSpy('bar');
-
-      test._mapEvents();
-      test.$view.click();
-      expect(test.trafalgar).not.toHaveBeenCalled();
-      expect(test.bar).not.toHaveBeenCalled();
-
-      test.$view.find(".foo").click();
-      expect(test.trafalgar).toHaveBeenCalled();
-      expect(test.bar).not.toHaveBeenCalled();
-
-      test.$view.find(".foo").select();
-      expect(test.trafalgar.calls.count()).toEqual(1);
-      expect(test.bar).toHaveBeenCalled();
-    });
-
-    it('properly handles null events', function() {
-      test.events = null;
-      expect(function() {
+        test.trafalgar = jasmine.createSpy();
         test._mapEvents();
-      }).not.toThrowError();
-      expect(test.events).toBeNull();
-    });
+        test.$view.click();
+        expect(test.trafalgar).toHaveBeenCalled();
+      });
 
-    it('properly handles when events is empty', function() {
-      test.events = { };
-      expect(function() {
+      it('does not trigger event that is not called', function() {
+        test.events = {
+          click: {
+            '.foo': 'trafalgar'
+          },
+          select: {
+            '.foo': 'bar'
+          }
+        };
+
+        test.trafalgar = jasmine.createSpy('trafalgar');
+        test.bar = jasmine.createSpy('bar');
+
         test._mapEvents();
-      }).not.toThrowError();
-      expect(test.events).toEqual({});
-    });
+        test.$view.click();
+        expect(test.trafalgar).not.toHaveBeenCalled();
+        expect(test.bar).not.toHaveBeenCalled();
 
-    it('properly handles an array of functions', function() {
-      var spy = jasmine.createSpy(),
+        test.$view.find(".foo").click();
+        expect(test.trafalgar).toHaveBeenCalled();
+        expect(test.bar).not.toHaveBeenCalled();
+
+        test.$view.find(".foo").select();
+        expect(test.trafalgar.calls.count()).toEqual(1);
+        expect(test.bar).toHaveBeenCalled();
+      });
+
+      it('triggers events when method is not found', function() {
+        test.events = {
+          click: 'trafalgar'
+        };
+
+        test._mapEvents();
+        test.trigger = jasmine.createSpy('event trigger');
+
+        test.$view.click();
+        expect(test.trigger).toHaveBeenCalled();
+        expect(test.trigger.calls.mostRecent().args[0]).toBe('trafalgar');
+      });
+
+      it('properly handles null events', function() {
+        test.events = null;
+        expect(function() {
+          test._mapEvents();
+        }).not.toThrowError();
+        expect(test.events).toBeNull();
+      });
+
+      it('properly handles when events is empty', function() {
+        test.events = { };
+        expect(function() {
+          test._mapEvents();
+        }).not.toThrowError();
+        expect(test.events).toEqual({});
+      });
+
+      it('properly handles an array of functions', function() {
+        var spy = jasmine.createSpy(),
           spy2 = jasmine.createSpy();
 
-      test.events = {
-        click: [spy, spy2, 'trafalgar']
-      };
+        test.events = {
+          click: [spy, spy2, 'trafalgar']
+        };
 
-      test.trafalgar = jasmine.createSpy('trafalgar');
+        test.trafalgar = jasmine.createSpy('trafalgar');
 
-      test._mapEvents();
-      test.$view.click();
-      expect(test.trafalgar).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalled();
-      expect(spy2).toHaveBeenCalled();
-      expect(test.trafalgar.calls.count()).toEqual(1);
-      expect(spy.calls.count()).toEqual(1);
-      expect(spy2.calls.count()).toEqual(1);
-    });
-  });
-
-  describe("_undelegateEvents", function() {
-    it('does not make calls after undelegated', function() {
-      test.events = {
-        click: 'trafalgar'
-      };
-
-      test.trafalgar = jasmine.createSpy();
-
-      test._mapEvents();
-      test.$view.click();
-      test._undelegateEvents();
-      test.$view.find(".foo").select();
-      expect(test.trafalgar.calls.count()).toEqual(1);
+        test._mapEvents();
+        test.$view.click();
+        expect(test.trafalgar).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalled();
+        expect(spy2).toHaveBeenCalled();
+        expect(test.trafalgar.calls.count()).toEqual(1);
+        expect(spy.calls.count()).toEqual(1);
+        expect(spy2.calls.count()).toEqual(1);
+      });
     });
 
-    it('properly handles when events is null', function() {
-      test.events = null;
-      test._mapEvents();
-      expect(test.events).toBeNull();
-      expect(function() {
+    describe("_undelegateEvents", function() {
+      it('does not make calls after undelegated', function() {
+        test.events = {
+          click: 'trafalgar'
+        };
+
+        test.trafalgar = jasmine.createSpy();
+
+        test._mapEvents();
+        test.$view.click();
         test._undelegateEvents();
-      }).not.toThrowError();
-      expect(test.events).toBeNull();
-    });
+        test.$view.find(".foo").select();
+        expect(test.trafalgar.calls.count()).toEqual(1);
+      });
 
-    it('properly handles when events is empty', function() {
-      test.events = { };
-      test._mapEvents();
-      expect(test.events).toEqual({});
-      expect(function() {
-        test._undelegateEvents();
-      }).not.toThrowError();
-      expect(test.events).toEqual({});
-    });
+      it('properly handles when events is null', function() {
+        test.events = null;
+        test._mapEvents();
+        expect(test.events).toBeNull();
+        expect(function() {
+          test._undelegateEvents();
+        }).not.toThrowError();
+        expect(test.events).toBeNull();
+      });
 
-    it('properly handles array of functions', function() {
-      var spy = jasmine.createSpy(),
+      it('properly handles when events is empty', function() {
+        test.events = { };
+        test._mapEvents();
+        expect(test.events).toEqual({});
+        expect(function() {
+          test._undelegateEvents();
+        }).not.toThrowError();
+        expect(test.events).toEqual({});
+      });
+
+      it('properly handles array of functions', function() {
+        var spy = jasmine.createSpy(),
           spy2 = jasmine.createSpy();
 
-      test.events = {
-        click: [spy, spy2, 'trafalgar']
-      };
+        test.events = {
+          click: [spy, spy2, 'trafalgar']
+        };
 
-      test.trafalgar = jasmine.createSpy('trafalgar');
+        test.trafalgar = jasmine.createSpy('trafalgar');
 
-      test._mapEvents();
-      test.$view.click();
-      test._undelegateEvents();
-      expect(test.trafalgar.calls.count()).toEqual(1);
-      expect(spy.calls.count()).toEqual(1);
-      expect(spy2.calls.count()).toEqual(1);
+        test._mapEvents();
+        test.$view.click();
+        test._undelegateEvents();
+        expect(test.trafalgar.calls.count()).toEqual(1);
+        expect(spy.calls.count()).toEqual(1);
+        expect(spy2.calls.count()).toEqual(1);
+      });
     });
   });
 });

--- a/trait/eventMappable.js
+++ b/trait/eventMappable.js
@@ -6,7 +6,13 @@ define(function() {
     if (typeof method === 'string') {
       return {
         method: function() {
-          self[method].apply(self, arguments);
+          if (self[method]) {
+            self[method].apply(self, arguments);
+          }
+          else {
+            Array.prototype.unshift.call(arguments, method);
+            self.trigger.apply(self, arguments);
+          }
         }
       };
     }

--- a/trait/eventMappable.js
+++ b/trait/eventMappable.js
@@ -1,17 +1,22 @@
 define(function() {
   'use strict';
 
-  var parse = function parse(method) {
-    var self = this;
+  var isEvent = /^:(.+)/,
+
+  parse = function parse(method) {
+    var self = this, event;
     if (typeof method === 'string') {
       return {
         method: function() {
           if (self[method]) {
             self[method].apply(self, arguments);
           }
-          else {
-            Array.prototype.unshift.call(arguments, method);
+          else if (event = isEvent.exec(method)) {
+            Array.prototype.unshift.call(arguments, event[1]);
             self.trigger.apply(self, arguments);
+          }
+          else {
+            throw new Error('Method "' + method + '" not found');
           }
         }
       };
@@ -31,10 +36,8 @@ define(function() {
   },
 
   decomposeEvent = function(method) {
-    var parseMethod = parse.bind(this);
-    return [].concat(Array.isArray(method) ?
-                     method.map(parseMethod) :
-                     parseMethod(method));
+    method = Array.isArray(method) ? method : [method];
+    return Array.prototype.concat.apply([], method.map(parse, this));
   };
 
   return {


### PR DESCRIPTION
When the method indicated by a string value isn't found, instead of
doing nothing, fire the string as an event.