### PR TITLE
Move RactiveModel to BeFF

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "karma-coverage": "^0.2.4",
     "karma-firefox-launcher": "^0.1.3",
     "karma-mocha-reporter": "^0.3.1",
-    "karma-phantomjs-launcher": "^0.1.4"
+    "karma-phantomjs-launcher": "^0.1.4",
+    "ractive": "~0.7.3"
   },
   "scripts": {
     "test": "grunt travis"

--- a/ractive/Model.js
+++ b/ractive/Model.js
@@ -1,0 +1,147 @@
+define([
+  'nbd/Model'
+], function(Model) {
+  'use strict';
+
+  return Model.extend({
+    /**
+     * @param  {String} id - keypath/subtree the model maintains
+     * @param  {ractive} ractive - the instance managing the parent tree
+     */
+    init: function(id, ractive) {
+      this._id = id;
+      this._r = ractive;
+      this._observer = this._r.observe(
+        this._id,
+        function(newValue, oldValue, keypath) { this.trigger(keypath, newValue, oldValue); },
+        { init: false, context: this }
+      );
+    },
+
+    destroy: function() {
+      this._observer.cancel();
+      this._super();
+    },
+
+    /** @returns {String} */
+    id: function() {
+      return this._id;
+    },
+
+    /**
+     * @param  {String} prop
+     * @return {*}
+     */
+    get: function(prop) {
+      return this._r.get(this.constructor.completePath(this.id(), prop));
+    },
+
+    /**
+     * @param {String} prop
+     * @param {String} value
+     * @returns {Boolean}
+     */
+    set: function(prop, value) {
+      if (value === undefined && typeof prop !== 'string') {
+        value = prop;
+        prop = undefined;
+      }
+      return this._r.set(this.constructor.completePath(this.id(), prop), value);
+    },
+
+    /** @param {String} path */
+    updateModel: function(path) {
+      return this._r.updateModel(this.constructor.completePath(this.id(), path));
+    },
+
+    /** @param  {String} path */
+    unset: function(path) {
+      path = this.constructor.completePath(this.id(), path).split('.');
+
+      var key = path.pop();
+      var obj = this._r.get(path.join('.'));
+
+      if (Array.isArray(obj)) {
+        obj.splice(+key, 1);
+      }
+      else {
+        delete obj[key];
+        this._r.update();
+      }
+    },
+
+    data: function() {
+      return this.get();
+    }
+  }, {
+    displayName: 'RactiveModel',
+
+    /**
+     * Path completion based on context and unnormalized path
+     */
+    completePath: function(context, local) {
+      var path;
+
+      if (!local) {
+        return context;
+      }
+
+      // Look for global escape: !path.to.data
+      if (path = /^!(.+)/.exec(local)) {
+        return path[1];
+      }
+      return context + '.' + local;
+    },
+
+    /**
+     * Captures foo:bar or url:/project or url:/http://www.be.net
+     *
+     * @param  {Object} ctxt
+     * @param  {String} ident
+     * @return {Boolean}
+     */
+    matchIdentity: function(ctxt, ident) {
+      var identRE = /(\w+?):(.+)/,
+          parts = identRE.exec(ident) || [],
+          key = parts[1],
+          value = parts[2];
+
+      // Intentional weak equality
+      // jshint eqeqeq: false
+      return ctxt[key] == value;
+    },
+
+    /**
+     * Matches identity strings with data
+     *
+     * @param context {Object | Object[]}
+     * @param identity {String}
+     *
+     * @example
+     *   var key = findByIdentity(objectOrArray, "id:24601");
+     */
+    findByIdentity: function(context, identity) {
+      var k;
+
+      for (k in context) {
+        if (context.hasOwnProperty(k) && this.matchIdentity(context[k], identity)) {
+          return k;
+        }
+      }
+    }
+  })
+  .mixin({
+    get _data() {
+      return this._r.get();
+    },
+
+    get ractive() {
+      return this._r;
+    },
+
+    /**
+     * @noop
+     */
+    set _data(data) { return data; }
+  });
+});

--- a/test/lib/karma.conf.js
+++ b/test/lib/karma.conf.js
@@ -39,6 +39,7 @@ module.exports = function(config) {
       'util/**/*.js': ['coverage'],
       'ux/**/*.js': ['coverage'],
       'View/**/*.js': ['coverage'],
+      'ractive/**/*.js': ['coverage'],
     },
 
     // test results reporter to use

--- a/test/lib/main.js
+++ b/test/lib/main.js
@@ -22,6 +22,7 @@ require.config({
     text: 'bower_components/requirejs-text/text',
     fixtures: 'test/fixtures',
     mocks: 'test/mocks',
+    Ractive: 'node_modules/ractive/ractive'
   },
 
   // dynamically load all test files

--- a/test/specs/ractive/Model.js
+++ b/test/specs/ractive/Model.js
@@ -1,0 +1,137 @@
+define([
+  'Ractive',
+  'ractive/Model'
+], function(Ractive, RactiveModel) {
+  'use strict';
+
+  describe('lib/RactiveModel', function() {
+    var data;
+    var ractive;
+    var ractiveModel;
+
+    beforeEach(function() {
+      data = {
+        foo: {
+          pages: [{
+            url: '/page-one'
+          }, {
+            url: '/page-two'
+          }]
+        },
+        pages: {
+          '/page-one': {
+            url: '/page-one',
+            title: 'Page One'
+          },
+          '/page-two': {
+            url: '/page-two',
+            title: 'Page Two'
+          }
+        }
+      };
+      ractive = new Ractive({data: data});
+      ractiveModel = new RactiveModel('foo.pages', ractive);
+    });
+
+    afterEach(function() {
+      if (ractive) {
+        ractive.teardown();
+      }
+      if (ractiveModel) {
+        ractiveModel.destroy();
+      }
+    });
+
+    describe('#id', function() {
+      it('returns the keypath', function() {
+        expect(ractiveModel.id()).toBe('foo.pages');
+      });
+
+      it('is replaceable', function() {
+        ractiveModel.id = jasmine.createSpy('id').and.returnValue('pages./page-two');
+
+        expect(ractiveModel.get('title')).toBe('Page Two');
+        ractiveModel.set('title', 'Page 2');
+
+        expect(ractiveModel.id).toHaveBeenCalled();
+        expect(ractive.get('pages./page-two.title')).toBe('Page 2');
+      });
+    });
+
+    describe('#unset', function() {
+      it('should remove the item from the ractive model based on the path', function() {
+        ractiveModel.unset('!pages./page-one');
+        expect(data.pages).toEqual({
+          '/page-two': {
+            url: '/page-two',
+            title: 'Page Two'
+          }
+        });
+      });
+
+      it('should fail not do anything when the path does not match existing data', function() {
+        ractiveModel.unset('!pages./nonexistent');
+        expect(data.pages).toEqual({
+          '/page-one': {
+            url: '/page-one',
+            title: 'Page One'
+          },
+          '/page-two': {
+            url: '/page-two',
+            title: 'Page Two'
+          }
+        });
+      });
+    });
+
+    describe('.completePath', function() {
+      it('joins portions of the keypath', function() {
+        expect(RactiveModel.completePath('foo', 'bar')).toBe('foo.bar');
+      });
+
+      it('returns the context if there is no local path', function() {
+        expect(RactiveModel.completePath('foo')).toBe('foo');
+      });
+
+      it('handles globally escaped local paths', function() {
+        expect(RactiveModel.completePath('foo', '!bar')).toBe('bar');
+      });
+    });
+
+    describe('.matchIdentity', function() {
+      beforeEach(function() {
+        this._context = {
+          foo: 1,
+          url: 'http://www.be.net'
+        };
+      });
+
+      it('returns whether or not the context is relevant to the identity', function() {
+        expect(RactiveModel.matchIdentity(this._context, 'bar:2')).toBe(false);
+        expect(RactiveModel.matchIdentity(this._context, 'foo:1')).toBe(true);
+        expect(RactiveModel.matchIdentity(this._context, 'url:http://www.be.net')).toBe(true);
+      });
+    });
+
+    describe('.findByIdentity', function() {
+      beforeEach(function() {
+        this._context = {
+          page1: {
+            foo: 1,
+            url: 'http://www.be.net'
+          },
+          page2: {
+            foo: 2,
+            bar: 3
+          }
+        };
+      });
+
+      it('returns the key whose value is relevant to the identity', function() {
+        expect(RactiveModel.findByIdentity(this._context, 'bar:2')).toBeUndefined();
+        expect(RactiveModel.findByIdentity(this._context, 'foo:1')).toBe('page1');
+        expect(RactiveModel.findByIdentity(this._context, 'bar:3')).toBe('page2');
+      });
+    });
+  });
+});


### PR DESCRIPTION
* Moves RactiveModel to `ractive/Model`
* Inlines some of `lib/util` from Portfolio into static methods about Ractive
* Adds tests for static methods