### PR TITLE
View/Dialog: guard against destroyed views

### DIFF
--- a/View/Dialog.js
+++ b/View/Dialog.js
@@ -68,7 +68,9 @@ define([
       this._shown = false;
 
       transitionEnd(this.$view).then(function() {
-        this.$view.hide();
+        if (this.$view) {
+          this.$view.hide();
+        }
       }.bind(this));
 
       this.$view.toggleClass(this._shownClass, this._shown);

--- a/View/Dialog.js
+++ b/View/Dialog.js
@@ -44,6 +44,10 @@ define([
 
     position: function() {},
 
+    _transitionEnd: function() {
+      return transitionEnd(this.$view);
+    },
+
     _shown: false,
     _shownClass: 'shown',
 
@@ -67,7 +71,7 @@ define([
       if (!this._shown) { return this; }
       this._shown = false;
 
-      transitionEnd(this.$view).then(function() {
+      this._hiding = this._transitionEnd().then(function() {
         if (this.$view) {
           this.$view.hide();
         }

--- a/test/specs/View/Dialog.js
+++ b/test/specs/View/Dialog.js
@@ -1,0 +1,25 @@
+define([
+  'View/Dialog',
+  'nbd/Promise',
+  'nbd/util/async'
+], function(View, Promise, async) {
+  'use strict';
+
+  describe('View/Dialog', function() {
+    it('does not throw when destroyed before a transition completes', function(done) {
+      var view = new View();
+      view.render();
+      view.show();
+
+      spyOn(view, '_transitionEnd').and.callFake(function() {
+        return new Promise(function(resolve) {
+          async(resolve);
+        });
+      });
+
+      view.hide();
+      view.destroy();
+      view._hiding.then(done);
+    });
+  });
+});


### PR DESCRIPTION
The transitionEnd callback needs to guard against destroyed views.