### PR TITLE
Validate: expose tests object as validate.tests

### DIFF
--- a/test/specs/util/validate.js
+++ b/test/specs/util/validate.js
@@ -103,6 +103,22 @@ define(['util/validate'], function(validate) {
       it('verifies optional values correctly for ' + key, verifyOptional.bind(this, key));
     }
 
+    it('allows new rules to be added', function() {
+      expect(validate.tests.requireTrimmed).not.toBeDefined();
+
+      validate.tests.requireTrimmed = {
+        test: function(corpus) {
+          return corpus.trim() !== '';
+        },
+        message: 'This field must not be blank'
+      };
+
+      validate('  ', 'requireTrimmed');
+      expect(validate.message).toEqual('This field must not be blank');
+
+      delete validate.tests.requireTrimmed;
+    });
+
     it('verifies required', function() {
       validate('', 'required,Generic');
       expect(validate.message).toEqual('This field is required');

--- a/util/validate.js
+++ b/util/validate.js
@@ -256,5 +256,7 @@ define(function() {
     return res;
   };
 
+  validate.tests = tests;
+
   return validate;
 });


### PR DESCRIPTION
So that consumers can modify it

cc @mikesherov, @Attamusc 