### PR TITLE
Draggable: Allow users to nullify the handle

### DIFF
--- a/test/specs/ui/trait/draggable.js
+++ b/test/specs/ui/trait/draggable.js
@@ -6,10 +6,10 @@ define([
 
   describe('ui/trait/draggable', function() {
     beforeEach(function() {
-      var $view = affix('div');
+      this._$view = affix('div');
 
       this.view = extend({
-        $view: $view
+        $view: this._$view
       }, draggable);
     });
 
@@ -29,6 +29,12 @@ define([
       expect($altView.draggable('option', 'handle')).toEqual('.test-handle');
       expect($altView.draggable('option', 'containment')).toEqual('.test-containment');
       expect($altView.draggable('option', 'cancel')).toEqual('input,textarea,button,select,option, .test-cancel');
+    });
+
+    it('allows a user to nullify the handle option', function() {
+      this.view.makeDraggable(this._$view, '');
+
+      expect(this.view.$view.draggable('option', 'handle')).toEqual('');
     });
   });
 });

--- a/ui/trait/draggable.js
+++ b/ui/trait/draggable.js
@@ -7,7 +7,7 @@ define([
       var cancelDefault;
 
       $view = $view || this.$view;
-      handle = handle || '.js-drag-handle';
+      handle = handle === undefined ? '.js-drag-handle' : handle;
       containment = containment || 'window';
       cancelSelector = cancelSelector || '.js-drag-cancel';
 


### PR DESCRIPTION
Ref https://github.com/adobe-community/issues/issues/7311

Beff dialog derivatives that want the entire dialog to be draggable either need to target the inner content and add a js-drag-handle class (doesn't always cover the entire dialog), or nullify the handle option so that the entire popup is draggable. 

I tried adding js-drag-handle as a container class of the dialog to no avail