### PR TITLE
Close popup dialog when you click the blocking div

### DIFF
--- a/View/Dialog/Popup.js
+++ b/View/Dialog/Popup.js
@@ -32,7 +32,9 @@ define([
       })
       .on('click', function(e) {
         e.stopPropagation();
-      })
+
+        this.hide();
+      }.bind(this))
       .insertAfter(this.$view);
     },
 

--- a/test/specs/View/Dialog/Popup.js
+++ b/test/specs/View/Dialog/Popup.js
@@ -1,0 +1,33 @@
+define([
+  'jquery',
+  'View/Dialog/Popup'
+], function($, Popup) {
+  'use strict';
+
+  describe('View/Dialog/Popup', function() {
+    beforeEach(function() {
+      this._$parent = affix('div');
+      this._popup = new Popup();
+      this._popup.render(this._$parent);
+    });
+
+    afterEach(function() {
+      this._popup.destroy();
+    });
+
+    it('closes when blocking div is clicked', function(done) {
+      var $block = this._$parent.find('.blocking-div');
+      this._popup.show();
+
+      expect($block.length).toBe(1);
+
+      $block.click();
+
+      this._popup._hiding.then(function() {
+        expect(this._$parent.find('.popup').css('display')).toBe('none');
+        expect($block.css('display')).toBe('none');
+        done();
+      }.bind(this));
+    });
+  });
+});


### PR DESCRIPTION
Worked with @mikesherov on this one. Appears that all usages of `View/Dialog/Popup` override the view so this is okay to do as a permanent non-configurable change.

@Attamusc @joesepi @kaicataldo