### PR TITLE
CloudUploader: Add static `setDropElement`

### DIFF
--- a/Component/CloudUploader.js
+++ b/Component/CloudUploader.js
@@ -445,6 +445,15 @@ define([
           uploader.choose();
         }
       });
+    },
+
+    setDropElement: function(element, cb) {
+      return new fineUploader.DragAndDrop({
+        dropZoneElements: [element],
+        callbacks: {
+          processingDroppedFilesComplete: cb
+        }
+      });
     }
   });
 });

--- a/test/specs/Component/CloudUploader.js
+++ b/test/specs/Component/CloudUploader.js
@@ -2,9 +2,10 @@ define([
   'jquery',
   'nbd/util/async',
   'nbd/Promise',
+  'fineuploader/all.fine-uploader',
   'mocks/fineuploader',
   'Component/CloudUploader'
-], function($, async, Promise, fineUploaderMock, CloudUploader) {
+], function($, async, Promise, fineUploader, fineUploaderMock, CloudUploader) {
   'use strict';
 
   describe('Component/CloudUploader', function() {
@@ -281,6 +282,34 @@ define([
             done();
           });
         });
+      });
+    });
+
+    describe('.setDropElement', function() {
+      beforeEach(function() {
+        spyOn(fineUploader, 'DragAndDrop');
+      });
+
+      it('returns an instance of fineuploader\'s DragAndDrop module', function() {
+        expect(CloudUploader.setDropElement(document.body)).toEqual(jasmine.any(fineUploader.DragAndDrop));
+      });
+
+      it('creates a DragAndDrop instance with the provided drop zone', function() {
+        CloudUploader.setDropElement(document.body);
+        expect(fineUploader.DragAndDrop).toHaveBeenCalledWith(jasmine.objectContaining({
+          dropZoneElements: [document.body]
+        }));
+      });
+
+      it('creates a DragAndDrop instance with the provided callback', function() {
+        var processingDoneFn = jasmine.createSpy();
+
+        CloudUploader.setDropElement(document.body, processingDoneFn);
+        expect(fineUploader.DragAndDrop).toHaveBeenCalledWith(jasmine.objectContaining({
+          callbacks: {
+            processingDroppedFilesComplete: processingDoneFn
+          }
+        }));
       });
     });
 


### PR DESCRIPTION
Allow consumers to statically register an upload drop area