### PR TITLE
Dialog: fire events when the dom can be interacted with

### DIFF
--- a/View/Dialog.js
+++ b/View/Dialog.js
@@ -59,6 +59,7 @@ define([
       $view.show();
       async(function() {
         $view.toggleClass(this._shownClass, this._shown);
+        this.trigger('visible', $view);
       }.bind(this));
 
       keyboard.on({
@@ -75,6 +76,7 @@ define([
         if (this.$view) {
           this.$view.hide();
         }
+        this.trigger('hidden', this.$view);
       }.bind(this));
 
       this.$view.toggleClass(this._shownClass, this._shown);

--- a/test/specs/View/Dialog.js
+++ b/test/specs/View/Dialog.js
@@ -21,5 +21,37 @@ define([
       view.destroy();
       view._hiding.then(done);
     });
+
+    it('fires the show event when ready to be shown', function(done) {
+      var context = affix('body');
+      var view = new View();
+      view.render(context);
+      view.on('show', done);
+      view.show();
+    });
+
+    it('fires the visible event when actually shown', function(done) {
+      var context = affix('body');
+      var view = new View();
+      view.render(context);
+      view.on('visible', function() {
+        expect(view.$view.is(':visible')).toBe(true);
+        done();
+      });
+      view.show();
+    });
+
+    it('fires the hidden event when closed', function(done) {
+      var context = affix('body');
+      var view = new View();
+      view.render(context);
+      view.on('hidden', function() {
+        expect(view.$view.is(':visible')).toBe(false);
+        done();
+      });
+      view.show();
+
+      view.hide();
+    });
   });
 });


### PR DESCRIPTION
The `show` event does not indicate when the element is actually visible for interaction. The new event is useful for functionality such as `autofocus` on async elements in dialogs