### PR TITLE
StickyPenScroller: update the last module only

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "intersection-observer-polyfill": "jeremenichelli/intersection-observer-polyfill#464b24f928710834d945d7a33f8a334d0db0f1c4",
     "jquery": "~2.1.1",
     "jquery-ui": "jquery/jquery-ui#1.11.4",
-    "lodash.debounce": "^4.0.8",
     "nbd": "^1.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
As the pen only shows up when the user hover over the module, there's no need to update every single hidden pen on the page. This optimization only updates the currently active one.