### PR TITLE
Feature/cloud uploader validator no reader data

### DIFF
--- a/Component/CloudUploader.js
+++ b/Component/CloudUploader.js
@@ -4,11 +4,10 @@ define([
   'nbd/trait/pubsub',
   'nbd/util/extend',
   '../Component',
-  '../dom/FileReader',
   './CloudUploader/facades/promise',
   './CloudUploader/facades/promises',
   'fineuploader/all.fine-uploader'
-], function($, Promise, pubsub, extend, Component, BeFileReader, promiseFacade, promisesFacade, fineUploader) {
+], function($, Promise, pubsub, extend, Component, promiseFacade, promisesFacade, fineUploader) {
   'use strict';
 
   /**
@@ -324,10 +323,8 @@ define([
 
       file.id = file.id || id;
 
-      return BeFileReader.promise(file)
-      .then(function(readerData) {
-        file.readerData = readerData;
-        return this._validator(file);
+      return new Promise(function(resolve) {
+        resolve(this._validator(file));
       }.bind(this))
       .then(function() {
         this.trigger('submit', {

--- a/dom/FileReader.js
+++ b/dom/FileReader.js
@@ -1,7 +1,6 @@
 define([
-  'nbd/Promise',
   '../Component'
-], function(Promise, Component) {
+], function(Component) {
   'use strict';
 
   /**

--- a/dom/FileReader.js
+++ b/dom/FileReader.js
@@ -12,7 +12,7 @@ define([
    */
   return Component.extend({
     init: function() {
-      this.reader = new window.FileReader();
+      this.reader = new FileReader();
     },
 
     /**

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function(config) {
     frameworks: ['jasmine-ajax', 'jasmine'],
 
     files: [
+      'node_modules/babel-polyfill/dist/polyfill.js',
       'node_modules/jquery/dist/jquery.js',
       'node_modules/jasmine-fixture/dist/jasmine-fixture.js',
       'test/index.js',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "nbd": "^1.1.5"
   },
   "devDependencies": {
+    "babel-polyfill": "^6.20.0",
     "eslint": "~3.4.0",
     "eslint-plugin-behance": "^1.0.0",
     "eslint-preset-behance": "^4.0.0",

--- a/test/specs/Component/CloudUploader.js
+++ b/test/specs/Component/CloudUploader.js
@@ -130,7 +130,6 @@ define([
         this.uploader.on('submit', function(data) {
           expect(data.name).toBeDefined();
           expect(data.id).toBeDefined();
-          expect(data.file.readerData).toBeDefined();
           done();
         });
         fineuploaderMock.fakeSubmit();
@@ -211,7 +210,6 @@ define([
         });
 
         Uploader.promise().then(function(fileArray) {
-          expect(fileArray[0].file.readerData).toBeDefined();
           expect(fileArray[1].file).toBe(null);
 
           Promise.all([
@@ -256,7 +254,6 @@ define([
         });
 
         Uploader.promise({}, files).then(function(fileArray) {
-          expect(fileArray[0].file.readerData).toBeDefined();
           expect(fileArray[1].file).toBe(null);
 
           Promise.all([

--- a/util/image.js
+++ b/util/image.js
@@ -41,7 +41,7 @@ define([], function() {
     },
 
     getBinaryFromDataUri: function(dataUri) {
-      return window.atob(dataUri.split(',')[1]);
+      return atob(dataUri.split(',')[1]);
     },
 
     /**

--- a/util/uploadValidator.js
+++ b/util/uploadValidator.js
@@ -1,7 +1,6 @@
 define([
-  './image',
-  'nbd/Promise'
-], function(image, Promise) {
+  './image'
+], function(image) {
   'use strict';
 
   return {


### PR DESCRIPTION
Three separate (breaking) commits.
Together they make a `major` version (after the merge).

---

1. `(breaking) CloudUploader: do not provide file.readerData to the validator`: this allows the validator to use web-workers and do the file-reading on the worker
2. `util/image: window.atob() -> atob() for workers`: `window` is unnecessary here and breaks when running in a worker
3.  `util/uploadValidator: use native Promise`: the `nbd/Promise` `async` depends on `window`, using natively provided `Promise` instead (all clients use a polyfill at this point).
