### PR TITLE
StickyPenScroller: Check for module presence before update

### DIFF
--- a/Component/StickyPenScroller.js
+++ b/Component/StickyPenScroller.js
@@ -40,6 +40,8 @@ define([
       var scrollTop;
 
       var update = function() {
+        if (!$module.length) { return; }
+
         var $pen = $module.find('.js-pen');
         var moduleOffsetTop = $module.offset().top;
         var $dropdown = $pen.next('.js-dropdown');


### PR DESCRIPTION
Fixes an issue where the pen scroller is initialized before there are any elements yet.