### PR TITLE
LazyLoadPicture: Extracted version of image lazy loading

### DIFF
--- a/Component/LazyLoadPicture.js
+++ b/Component/LazyLoadPicture.js
@@ -1,0 +1,64 @@
+define([
+  'jquery',
+  '../Component',
+  'jquery-lazyload'
+], function($, Component) {
+  'use strict';
+
+  function swapAttr($elem, attr) {
+    var property = 'data-' + attr;
+
+    if ($elem.attr(property)) {
+      $elem
+      .attr(attr, $elem.data(attr))
+      .removeAttr(property);
+    }
+  }
+
+  return Component.extend({
+    init: function($elem, options) {
+      this._$elem = $elem;
+      this._options = options;
+    },
+
+    bind: function() {
+      // Appear event is triggered by $.fn.lazyload
+      this._$elem.on('appear', function createPictureElementFromElement() {
+        var $elem = $(this);
+        var $img = $elem.is('img') ? $elem : $elem.find('img');
+        var $sources = $elem.find('source');
+
+        $img.one('load', function() {
+          $img
+          .removeAttr('height')
+          .removeAttr('width')
+          .removeAttr('style')
+          .addClass('image-loaded');
+        });
+
+        swapAttr($img, 'srcset');
+        swapAttr($img, 'src');
+        swapAttr($img, 'sizes');
+
+        $sources.each(function(_, source) {
+          var $source = $(source);
+
+          swapAttr($source, 'srcset');
+          swapAttr($source, 'media');
+        }.bind(this));
+      });
+
+      this._$elem.lazyload(this._options);
+
+      // lazyload doesn't fire on window resize so we are doing it manually
+      $(window).one('resize.beff-lazyloadpicture', function() {
+        this._$elem.trigger('appear');
+      }.bind(this));
+    },
+
+    unbind: function() {
+      $(window).off('resize.beff-lazyloadpicture');
+      this._$elem.off('appear');
+    }
+  });
+});

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,6 +25,7 @@ module.exports = function(config) {
       'node_modules/babel-polyfill/dist/polyfill.js',
       'node_modules/jquery/dist/jquery.js',
       'node_modules/jasmine-fixture/dist/jasmine-fixture.js',
+      'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
       'test/index.js',
       { pattern: 'test/fixtures/**/*', included: false },
       { pattern: '**/*.js', included: false }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "intersection-observer-polyfill": "jeremenichelli/intersection-observer-polyfill#464b24f928710834d945d7a33f8a334d0db0f1c4",
     "jquery": "~2.1.1",
     "jquery-ui": "jquery/jquery-ui#1.11.4",
+    "jquery-lazyload": "~1.9.7",
     "nbd": "^1.1.5",
     "tiny-script-loader": "^1.1.0"
   },
@@ -24,6 +25,7 @@
     "istanbul-instrumenter-loader": "^0.1.3",
     "jasmine-core": "^2.3.0",
     "jasmine-fixture": "~1.3.3",
+    "jasmine-jquery": "2.1.1",
     "karma": "~1.1.1",
     "karma-coverage": "~1.1.0",
     "karma-jasmine": "~1.0.2",

--- a/test/fixtures/Component/LazyLoadPicture.html
+++ b/test/fixtures/Component/LazyLoadPicture.html
@@ -1,0 +1,16 @@
+<picture class="js-lazy">
+  <source data-srcset="cat.jpg" data-media="(max-width: 600px)">
+  <source data-srcset="dog.jpg" data-media="(min-width: 601px)">
+  <img src="dog.jpg" data-src="cat.jpg" height="100" width="100" style="padding-bottom: 100%;">
+</picture>
+
+<img
+  class="js-lazy"
+  src=""
+  data-src="cat.jpg"
+  data-srcset="dog.jpg"
+  data-sizes="(max-width: 1400px) 100vw, 1400px"
+  width="100"
+  height="0"
+  style="padding-bottom: 100%"
+>

--- a/test/specs/Component/LazyLoadPicture.js
+++ b/test/specs/Component/LazyLoadPicture.js
@@ -1,0 +1,95 @@
+define([
+  'jquery',
+  'Component/LazyLoadPicture',
+  'text!fixtures/Component/LazyLoadPicture.html'
+], function($, LazyLoadPicture, fixture) {
+  'use strict';
+
+  describe('be/LazyLoadPicture', function() {
+    beforeEach(function() {
+      affix('div').append(fixture);
+
+      this._$lazyPicture = $('picture.js-lazy');
+      this._$lazyImg = $('img.js-lazy');
+      this._$img = this._$lazyPicture.find('img');
+      this._$sources = this._$lazyPicture.find('source');
+    });
+
+    it('lazyloads the picture\'s image and sources on window resize', function() {
+      var src = this._$img.data('src');
+      var lazyLoadPicture;
+      var expectedAttrs = [];
+
+      expect(this._$img.attr('src')).not.toBe(src);
+      this._$sources.each(function(_, source) {
+        var $source = $(source);
+        expectedAttrs.push($source.data());
+
+        expect($source).not.toHaveAttr('srcset');
+        expect($source).not.toHaveAttr('media');
+      });
+
+      lazyLoadPicture = LazyLoadPicture.init(this._$lazyPicture);
+
+      $(window).trigger('resize');
+
+      expect(this._$img).not.toHaveAttr('data-src');
+      expect(this._$img).toHaveAttr('src', src);
+      this._$sources.each(function(i, source) {
+        var $source = $(source);
+
+        expect($source).not.toHaveAttr('data-media');
+        expect($source).not.toHaveAttr('data-srcset');
+        expect($source).toHaveAttr('srcset', expectedAttrs[i].srcset);
+        expect($source).toHaveAttr('media', expectedAttrs[i].media);
+      });
+
+      lazyLoadPicture.destroy();
+    });
+
+    it('lazyloads the img src, srcset, and sizes on window resize', function() {
+      var src = this._$lazyImg.data('src');
+      var srcset = this._$lazyImg.data('srcset');
+      var sizes = this._$lazyImg.data('sizes');
+
+      var lazyLoadPicture;
+
+      expect(this._$lazyImg.attr('src')).not.toBe(src);
+      expect(this._$lazyImg.attr('srcset')).not.toBe(srcset);
+      expect(this._$lazyImg.attr('sizes')).not.toBe(sizes);
+
+      lazyLoadPicture = LazyLoadPicture.init(this._$lazyImg);
+
+      $(window).trigger('resize');
+
+      expect(this._$lazyImg).not.toHaveAttr('data-src');
+      expect(this._$lazyImg).not.toHaveAttr('data-srcset');
+      expect(this._$lazyImg).not.toHaveAttr('data-sizes');
+
+      expect(this._$lazyImg.attr('src')).toBe(src);
+      expect(this._$lazyImg.attr('srcset')).toBe(srcset);
+      expect(this._$lazyImg.attr('sizes')).toBe(sizes);
+
+      lazyLoadPicture.destroy();
+    });
+
+    it('removes dimension attrs and style once image is loaded', function(done) {
+      var lazyLoadPicture = LazyLoadPicture.init(this._$lazyPicture);
+
+      this._$lazyPicture.on('appear', function() {
+        expect(this._$img).toHaveAttr('height');
+        expect(this._$img).toHaveAttr('width');
+        expect(this._$img).toHaveAttr('style');
+
+        this._$img.trigger('load');
+
+        expect(this._$img).not.toHaveAttr('height');
+        expect(this._$img).not.toHaveAttr('width');
+        expect(this._$img).not.toHaveAttr('style');
+
+        lazyLoadPicture.destroy();
+        done();
+      }.bind(this));
+    });
+  });
+});


### PR DESCRIPTION
Extracting module from the apps.

## NOTE
This will be a minor change as it will require a change in the consumers webpack config to address `jquery-lazyload`s dependency on a globally available `jQuery` (but only if you require this module).

Example:
```
loaders: [
  {
    test: /jquery.lazyload.*\.js$/,
    loader: 'imports-loader?jQuery=jquery',
    enforce: 'pre',
  },
]
```