### PR TITLE
Upload Validator: modify CMYK validator to resolve a Promise with an array of warnings.

### DIFF
--- a/test/specs/util/uploadValidator.js
+++ b/test/specs/util/uploadValidator.js
@@ -30,5 +30,32 @@ define([
         });
       });
     });
+
+    describe('.CMYKWarning', function() {
+      it('returns a promise with an array containing a warning when validating a CMYK image', function(done) {
+        var data = { readerData: fixtureData.cmykKoala };
+        uploadValidator.CMYKWarning(data).then(function(warnings) {
+          expect(warnings).toEqual(['Your images look best on the web in RGB instead of CMYK. Please upload koala.jpeg as a RGB image.']);
+          done();
+        });
+      });
+
+      it('returns a promise with an empty array when validating a RGB image', function(done) {
+        var data = { readerData: fixtureData.rgbGrant };
+        uploadValidator.CMYKWarning(data).then(function(warnings) {
+          expect(warnings).toEqual([]);
+          done();
+        });
+      });
+
+      it('appends the CMYK warning to optionally passed in array of existing warnings', function(done) {
+        var data = { readerData: fixtureData.cmykKoala };
+        var existingWarnings = ['foo'];
+        uploadValidator.CMYKWarning(data, existingWarnings).then(function(warnings) {
+          expect(warnings).toEqual(['foo', 'Your images look best on the web in RGB instead of CMYK. Please upload koala.jpeg as a RGB image.']);
+          done();
+        });
+      });
+    });
   });
 });

--- a/util/uploadValidator.js
+++ b/util/uploadValidator.js
@@ -12,6 +12,18 @@ define([
 
         resolve(file);
       });
+    },
+
+    CMYKWarning: function(file, warnings) {
+      warnings = Array.isArray(warnings) ? warnings : [];
+
+      return new Promise(function(resolve) {
+        if (file.readerData.isImage && image.isCMYK(image.getBinaryFromDataUri(file.readerData.result))) {
+          warnings.push('Your images look best on the web in RGB instead of CMYK. Please upload ' + file.readerData.name + ' as a RGB image.');
+        }
+
+        resolve(warnings);
+      });
     }
   };
 });


### PR DESCRIPTION
```
lib/uploadValidator
    .CMYKWarning
      ✔ returns a promise with an array containing a warning when validating a CMYK image
      ✔ returns a promise with an empty array when validating a RGB image
      ✔ appends warning to optionally passed in array of existing warnings
```

Addresses: https://github.com/adobe-community/issues/issues/14395