### PR TITLE
draggable: unset height on dragstop

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,6 +24,7 @@ module.exports = function(config) {
     files: [
       'node_modules/babel-polyfill/dist/polyfill.js',
       'node_modules/jquery/dist/jquery.js',
+      'node_modules/jquery-simulate/jquery.simulate.js',
       'node_modules/jasmine-fixture/dist/jasmine-fixture.js',
       'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
       'test/index.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "beff",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -225,33 +225,58 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
-    "aws4": {
-      "version": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-      "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
-      "dev": true
-    },
     "babel-polyfill": {
-      "version": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.22.0.tgz",
-      "integrity": "sha1-GsmevcxrpNseJhjDh7IISoIVSjs=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
-      }
-    },
-    "babel-runtime": {
-      "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-      "integrity": "sha1-HPi0rGfHek3bDbKuH3TeUqxMphE=",
-      "dev": true,
-      "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.0",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.0",
+            "regenerator-runtime": "0.11.0"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+              "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+              "dev": true
+            }
+          }
+        },
+        "core-js": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+          "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
       }
     },
     "backo2": {
@@ -319,14 +344,6 @@
       "version": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz",
       "integrity": "sha1-qiGEy8Q00phixmppv4HMCjOD7nk=",
       "dev": true
-    },
-    "bl": {
-      "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-      }
     },
     "blob": {
       "version": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
@@ -543,11 +560,6 @@
         "redeyed": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz"
       }
     },
-    "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-      "dev": true
-    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -577,7 +589,6 @@
       "requires": {
         "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
         "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-        "fsevents": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
         "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -682,14 +693,6 @@
       "dev": true,
       "requires": {
         "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-      }
-    },
-    "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
       }
     },
     "component-bind": {
@@ -1102,11 +1105,6 @@
         "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
       }
     },
-    "es6-promise": {
-      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=",
-      "dev": true
-    },
     "es6-set": {
       "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
       "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
@@ -1262,16 +1260,18 @@
       }
     },
     "eslint-plugin-behance": {
-      "version": "https://registry.npmjs.org/eslint-plugin-behance/-/eslint-plugin-behance-1.0.0.tgz",
-      "integrity": "sha1-7AEU6lTuFPwOv5He0RNevT/7a/U=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-behance/-/eslint-plugin-behance-1.1.0.tgz",
+      "integrity": "sha1-GGfvtokXcyU6TYlYwcdV04o0McQ=",
       "dev": true,
       "requires": {
         "requireindex": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz"
       }
     },
     "eslint-preset-behance": {
-      "version": "https://registry.npmjs.org/eslint-preset-behance/-/eslint-preset-behance-4.0.0.tgz",
-      "integrity": "sha1-QDPQIlVZa/pTbgBKlULBLqOWoQo=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-preset-behance/-/eslint-preset-behance-4.1.0.tgz",
+      "integrity": "sha1-iiFvXBsHZY1AAK3HTd4BucrNmcM=",
       "dev": true
     },
     "espree": {
@@ -1414,43 +1414,6 @@
         "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
     },
-    "extract-zip": {
-      "version": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-      "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-        "debug": "0.7.4",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-        "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
-          "dev": true,
-          "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-            "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-          }
-        },
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          }
-        }
-      }
-    },
     "extsprintf": {
       "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
@@ -1557,8 +1520,7 @@
       }
     },
     "fine-uploader": {
-      "version": "git://github.com/behance/fine-uploader.git#da68915147ef5a2ab3ff4667464cad0f516e1886",
-      "integrity": "sha1-oRCV5sEXR490nBzN8pHMUJxrH3A="
+      "version": "git://github.com/behance/fine-uploader.git#da68915147ef5a2ab3ff4667464cad0f516e1886"
     },
     "flat-cache": {
       "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz",
@@ -1589,981 +1551,10 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
-    "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-      "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
-      },
-      "dependencies": {
-        "async": {
-          "version": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
-          "dev": true,
-          "requires": {
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
-          }
-        }
-      }
-    },
-    "fs-extra": {
-      "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
-        "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-      }
-    },
     "fs.realpath": {
       "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
-      "integrity": "sha1-VY6Mw4ZD2O9A/kUVhIbQ0ldY7uQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-        "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-          "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
-          }
-        },
-        "asn1": {
-          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
-          "optional": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-          "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
-        },
-        "bl": {
-          "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-          "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-              }
-            }
-          }
-        },
-        "block-stream": {
-          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true,
-          "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-          }
-        },
-        "boom": {
-          "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-          }
-        },
-        "brace-expansion": {
-          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-          "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-          }
-        },
-        "buffer-shims": {
-          "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true,
-          "optional": true
-        },
-        "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-          }
-        },
-        "code-point-at": {
-          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-          "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-          }
-        },
-        "combined-stream": {
-          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-          }
-        },
-        "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-          }
-        },
-        "concat-map": {
-          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-          }
-        },
-        "dashdash": {
-          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "deep-extend": {
-          "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "delegates": {
-          "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true,
-          "optional": true
-        },
-        "extend": {
-          "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-          "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "1.5.2",
-            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
-          }
-        },
-        "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "fstream": {
-          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
-          }
-        },
-        "fstream-ignore": {
-          "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
-          }
-        },
-        "gauge": {
-          "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-          "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-            "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
-          }
-        },
-        "generate-function": {
-          "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-          "dev": true,
-          "optional": true
-        },
-        "generate-object-property": {
-          "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-          }
-        },
-        "getpass": {
-          "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-          }
-        },
-        "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
-          "dev": true
-        },
-        "graceful-readlink": {
-          "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-          }
-        },
-        "has-ansi": {
-          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-          }
-        },
-        "has-color": {
-          "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-          "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-          "dev": true,
-          "optional": true
-        },
-        "has-unicode": {
-          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-          }
-        },
-        "hoek": {
-          "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-            "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz"
-          }
-        },
-        "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
-          "dev": true,
-          "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
-        },
-        "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        },
-        "ini": {
-          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-          }
-        },
-        "is-my-json-valid": {
-          "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-          "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-          }
-        },
-        "is-property": {
-          "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-          "dev": true,
-          "optional": true
-        },
-        "is-typedarray": {
-          "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-          }
-        },
-        "jsbn": {
-          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-          "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
-          "dev": true,
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true,
-          "optional": true
-        },
-        "jsonpointer": {
-          "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-          "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-          "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-            "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-            "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-          }
-        },
-        "mime-db": {
-          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-          "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-          "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
-          "dev": true,
-          "requires": {
-            "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
-          }
-        },
-        "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-          "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
-          }
-        },
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
-          "integrity": "sha1-sL0TY1uvfRvnriM8FvvPMwms03w=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-            "rc": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-            "request": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
-          }
-        },
-        "node-uuid": {
-          "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
-          "dev": true,
-          "optional": true
-        },
-        "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
-          }
-        },
-        "npmlog": {
-          "version": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-          "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-          }
-        },
-        "number-is-nan": {
-          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
-        },
-        "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true,
-          "optional": true
-        },
-        "pinkie-promise": {
-          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-          }
-        },
-        "process-nextick-args": {
-          "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-          "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs=",
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-          "integrity": "sha1-cLl5HG/LhIDbRL0VWg9rtY8XJGg=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        },
-        "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
-          "integrity": "sha1-X3ip/eQ3CryP9kedeoSnGhS4eKI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-            "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "qs": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-          }
-        },
-        "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-          "integrity": "sha1-bl792kqi8DQX9rKldK7Cn0tlJwU=",
-          "dev": true,
-          "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
-          }
-        },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-          "integrity": "sha1-KBmVuAwUSCCUFd28TPUMJpzvVcU=",
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-          "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-          }
-        },
-        "sshpk": {
-          "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-          "integrity": "sha1-iQzJ1hTcUpLlyxpUOwPJq6pcN04=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-            "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-            "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-            "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-          "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-          }
-        },
-        "stringstream": {
-          "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-          }
-        },
-        "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-          }
-        },
-        "tar-pack": {
-          "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
-          "integrity": "sha1-vIz5oi9YMnOfEvORDaweuXtJcIw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-          }
-        },
-        "tough-cookie": {
-          "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
-          "dev": true,
-          "optional": true
-        },
-        "tunnel-agent": {
-          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true,
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-          "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "verror": {
-          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-          }
-        },
-        "wide-align": {
-          "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
-          }
-        },
-        "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "generate-function": {
       "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -2656,11 +1647,6 @@
       "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
       "dev": true
     },
-    "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "growly": {
       "version": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
@@ -2676,16 +1662,11 @@
         "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz"
       }
     },
-    "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "dev": true
     },
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2902,8 +1883,7 @@
       "dev": true
     },
     "intersection-observer-polyfill": {
-      "version": "git://github.com/jeremenichelli/intersection-observer-polyfill.git#464b24f928710834d945d7a33f8a334d0db0f1c4",
-      "integrity": "sha1-4vEyh1c3UrrirjMbXdn8Xkfb8KQ="
+      "version": "git://github.com/jeremenichelli/intersection-observer-polyfill.git#464b24f928710834d945d7a33f8a334d0db0f1c4"
     },
     "invert-kv": {
       "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -3091,7 +2071,6 @@
     },
     "istanbul": {
       "version": "git://github.com/gotwarlost/istanbul.git#db701e170ba4cb11af3bac09411296cdb0e8215a",
-      "integrity": "sha1-dC1Br3XUqESFVHAqWCF9AZhTJBE=",
       "dev": true,
       "requires": {
         "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -3163,8 +2142,9 @@
       "dev": true
     },
     "jasmine-core": {
-      "version": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.1.tgz",
-      "integrity": "sha1-X4NHO27yT1oo/15SA8TyfDQMpus=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
       "dev": true
     },
     "jasmine-fixture": {
@@ -3195,9 +2175,12 @@
       "resolved": "https://registry.npmjs.org/jquery-lazyload/-/jquery-lazyload-1.9.7.tgz",
       "integrity": "sha1-mYKziMUzwLYRIUs8WqoLn+3gcfc="
     },
+    "jquery-simulate": {
+      "version": "github:jquery/jquery-simulate#55bf0789accaeaaf403eb0b55953d64116f4d3f6",
+      "dev": true
+    },
     "jquery-ui": {
-      "version": "git://github.com/jquery/jquery-ui.git#d6713024e16de90ea71dc0544ba34e1df01b4d8a",
-      "integrity": "sha1-Kc6gLFRT5gey5nByAj3ks8Masz0="
+      "version": "git://github.com/jquery/jquery-ui.git#d6713024e16de90ea71dc0544ba34e1df01b4d8a"
     },
     "js-yaml": {
       "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
@@ -3245,11 +2228,6 @@
     "json5": {
       "version": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
       "integrity": "sha1-myBxWwJsvjd4/Xae3M2CLYMypbI=",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
-      "integrity": "sha1-KLyynFlrW3qv005mKjKbpizYQvw=",
       "dev": true
     },
     "jsonify": {
@@ -3512,35 +2490,340 @@
       }
     },
     "karma-phantomjs-launcher": {
-      "version": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.2.tgz",
-      "integrity": "sha1-GeEEFJj9dVY+2Gcwoiwf5Xn6j7E=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
+      "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-        "phantomjs-prebuilt": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.12.tgz"
+        "lodash": "4.17.4",
+        "phantomjs-prebuilt": "2.1.15"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+          }
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "readable-stream": "2.3.3",
+            "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "es6-promise": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+          "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
+          "dev": true
+        },
+        "extract-zip": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+          "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+          "dev": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "debug": "2.2.0",
+            "mkdirp": "0.5.0",
+            "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "mime-types": "2.1.16"
+          }
+        },
+        "fs-extra": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.29.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+          "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.16",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+          "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.29.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          }
+        },
+        "phantomjs-prebuilt": {
+          "version": "2.1.15",
+          "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
+          "integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
+          "dev": true,
+          "requires": {
+            "es6-promise": "4.0.5",
+            "extract-zip": "1.6.5",
+            "fs-extra": "1.0.0",
+            "hasha": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+            "kew": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+            "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "request": "2.81.0",
+            "request-progress": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+            "which": "1.2.14"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "2.1.16",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "dev": true,
+          "requires": {
+            "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "which": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        }
       }
     },
     "karma-webpack": {
-      "version": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.2.tgz",
-      "integrity": "sha1-vTg1CvVkXJZECQdwk56+fOcm+GQ=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.4.tgz",
+      "integrity": "sha1-Pi1PSLqUqHjhxmu44a5hKJh6F1s=",
       "dev": true,
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+        "async": "0.9.2",
+        "loader-utils": "0.2.17",
+        "lodash": "3.10.1",
         "source-map": "0.1.43",
-        "webpack-dev-middleware": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz"
+        "webpack-dev-middleware": "1.12.0"
       },
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         },
+        "emojis-list": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+          "dev": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "webpack-dev-middleware": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
+          "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+          "dev": true,
+          "requires": {
+            "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+            "mime": "1.3.6",
+            "path-is-absolute": "1.0.1",
+            "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "time-stamp": "2.0.0"
+          }
         }
       }
     },
@@ -3556,11 +2839,6 @@
       "requires": {
         "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
       }
-    },
-    "klaw": {
-      "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-      "integrity": "sha1-iFe/vB2CS63xPT0CQdi75G+xL3M=",
-      "dev": true
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -3845,6 +3123,12 @@
         "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.0.7.tgz"
       }
     },
+    "mime": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
+      "dev": true
+    },
     "mime-db": {
       "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
       "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
@@ -3894,12 +3178,6 @@
       "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
-    },
-    "nan": {
-      "version": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
-      "dev": true,
-      "optional": true
     },
     "natural-compare": {
       "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3981,11 +3259,6 @@
           "dev": true
         }
       }
-    },
-    "node-uuid": {
-      "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-      "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
-      "dev": true
     },
     "nopt": {
       "version": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -4229,31 +3502,11 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "phantomjs-prebuilt": {
-      "version": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.12.tgz",
-      "integrity": "sha1-a7p9qQzD+hRS2s9O+DlokkcX9/U=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-        "extract-zip": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-        "hasha": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-        "kew": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-        "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-        "request-progress": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.11.tgz"
-      },
-      "dependencies": {
-        "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-          "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
-          "dev": true,
-          "requires": {
-            "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-          }
-        }
-      }
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "dev": true
     },
     "pify": {
       "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -4328,6 +3581,12 @@
     "qjobs": {
       "version": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
       "integrity": "sha1-ZZ3p8s+NzCehSBJ28gU3cnI4LnM=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
       "dev": true
     },
     "querystring": {
@@ -4463,11 +3722,6 @@
         }
       }
     },
-    "regenerator-runtime": {
-      "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-      "integrity": "sha1-JX9BlhzkRVixj3gUr0jBdVn5+us=",
-      "dev": true
-    },
     "regex-cache": {
       "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
@@ -4493,41 +3747,6 @@
       "dev": true,
       "requires": {
         "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-      }
-    },
-    "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-      "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-        "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-        "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-        "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-          "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
-          "dev": true
-        }
       }
     },
     "request-progress": {
@@ -4619,6 +3838,12 @@
     "rx-lite": {
       "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "semver": {
@@ -4976,6 +4201,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "time-stamp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
+      "dev": true
+    },
     "timers-browserify": {
       "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
       "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
@@ -5006,11 +4237,6 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-      "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
-      "dev": true
-    },
     "trim-newlines": {
       "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
@@ -5024,11 +4250,6 @@
     "tty-browserify": {
       "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-      "dev": true
-    },
-    "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true
     },
     "tv4": {
@@ -5366,24 +4587,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "webpack-dev-middleware": {
-      "version": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz",
-      "integrity": "sha1-fVviZR5pL936/Yqu0XfBb/UfDrg=",
-      "dev": true,
-      "requires": {
-        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jasmine-core": "^2.3.0",
     "jasmine-fixture": "~1.3.3",
     "jasmine-jquery": "2.1.1",
+    "jquery-simulate": "jquery/jquery-simulate#v1.0.1",
     "karma": "~1.1.1",
     "karma-coverage": "~1.1.0",
     "karma-jasmine": "~1.0.2",

--- a/test/specs/ui/trait/draggable.js
+++ b/test/specs/ui/trait/draggable.js
@@ -7,6 +7,7 @@ define([
   describe('ui/trait/draggable', function() {
     beforeEach(function() {
       this._$view = affix('div');
+      this._$view.affix('.js-drag-handle');
 
       this.view = extend({
         $view: this._$view
@@ -35,6 +36,22 @@ define([
       this.view.makeDraggable(this._$view, '');
 
       expect(this.view.$view.draggable('option', 'handle')).toEqual('');
+    });
+
+    it('unsets inline height after dragging', function(done) {
+      this.view.makeDraggable();
+
+      this.view.$view.on('dragstop', function() {
+        expect(this.view.$view[0].style.height).toEqual('');
+        done();
+      }.bind(this));
+
+      this.view.$view
+        .find('.js-drag-handle')
+        .simulate('drag', {
+          dx: 10,
+          dy: 10,
+        });
     });
   });
 });

--- a/ui/trait/draggable.js
+++ b/ui/trait/draggable.js
@@ -13,7 +13,11 @@ define([
 
       $view.draggable({
         handle: handle,
-        containment: containment
+        containment: containment,
+        stop: function() {
+          // https://bugs.jqueryui.com/ticket/10725
+          this.style.removeProperty('height');
+        }
       });
 
       cancelDefault = $view.draggable('option', 'cancel');


### PR DESCRIPTION
Workaround for https://bugs.jqueryui.com/ticket/10725 until we upgrade.

jquery-ui sets an explicit height as it's dragging, which isn't great for things that have flexible/varying heights.

It looks like this was fixed in a later release, so we should be able to get rid of this code when we upgrade.