### PR TITLE
ux/keyboard: initialize lazily

### DIFF
--- a/ux/keyboard.js
+++ b/ux/keyboard.js
@@ -16,7 +16,7 @@ define(['jquery', 'nbd/Class'], function($, Class) {
     };
   }
 
-  var keyhandler = new (Class.extend({
+  var KeyHandler = Class.extend({
     listeners: null,
     globals: null,
 
@@ -203,12 +203,20 @@ define(['jquery', 'nbd/Class'], function($, Class) {
       122: true,
       123: true
     }
-  }))();
+  });
+
+  var keyhandler;
+  function lazyCallMethod(methodName) {
+    return function() {
+      keyhandler = keyhandler || new KeyHandler();
+      keyhandler[methodName].apply(keyhandler, arguments);
+    };
+  }
 
   return {
-    on: keyhandler.addListener,
-    off: keyhandler.removeListener,
-    add: keyhandler.appendListener,
-    global: keyhandler.addGlobal
+    on: lazyCallMethod('addListener'),
+    off: lazyCallMethod('removeListener'),
+    add: lazyCallMethod('appendListener'),
+    global: lazyCallMethod('addGlobal')
   };
 });


### PR DESCRIPTION
This change is motivated by the desire to statically import `ux/keyboard` into an isomorphic component, where `ux/keyboard` is used in the `mounted` (browser-only) phase. This is currently not possible because the keyhandler self-invokes and its `init` depends on the browser-only `document`.

The change ensures that the keyhandler is only initialized when one of the exported methods are executed; which happens in the `mounted` phase in the browser.