### PR TITLE
StickyPenScroller: add left boundary option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/eslint-preset-behance/.eslintrc",
   "parserOptions": {
+    "ecmaVersion": 5,
     "sourceType": "script"
   },
   "env": {

--- a/Component/StickyPenScroller.js
+++ b/Component/StickyPenScroller.js
@@ -12,6 +12,8 @@ define([
       this.moduleClass = options.moduleClass;
       this.offset = options.offset || 0;
       this.$context = options.$context;
+      this.leftBoundaryWidth = options.leftBoundaryWidth;
+      this.initialPenLeftPosition = null;
 
       this.penTopPosForShortModules = -10;
       this.$modules = $(this.moduleClass);
@@ -29,7 +31,9 @@ define([
       }.bind(this));
 
       this.$context.on('mouseup.stickyPenScroller', '.js-pen', function(e) {
-        this._adjustDropdownFromPen($(e.currentTarget));
+        var $pen = $(e.currentTarget);
+        this._checkAndSetLeftBoundaryForPen($pen);
+        this._adjustDropdownFromPen($pen);
       }.bind(this));
 
       this._setWindowScroller();
@@ -50,13 +54,16 @@ define([
         // top and bottom scroll bounds for each module
         if (offsettedScrollTop > moduleOffsetTop && offsettedScrollTop < this._getScrollBottomLimit($module, $pen)) {
           $pen.css('top', offsettedScrollTop - moduleOffsetTop + this.penMargin);
+          this._checkAndSetLeftBoundaryForPen($pen);
           this._fixDropDownPosition($dropdown, $pen);
         }
         else if ($module.outerHeight() < $pen.outerHeight()) {
           $pen.css('top', this.penTopPosForShortModules);
+          this._checkAndSetLeftBoundaryForPen($pen);
         }
         else {
           $pen.css('top', this.penMargin);
+          this._checkAndSetLeftBoundaryForPen($pen);
           this._fixDropDownPosition($dropdown, $pen);
         }
       }.bind(this);
@@ -91,10 +98,12 @@ define([
         window.setTimeout(function() {
           $dropdown = $pen.next('.js-dropdown');
           $dropdown.css('top', $pen.position().top + penHeight + this.dropDownMargin);
+          this._checkAndSetLeftBoundaryForDropdown($pen, $dropdown);
         }.bind(this), 1);
       }
 
       $dropdown.css('top', $pen.position().top + penHeight + this.dropDownMargin);
+      this._checkAndSetLeftBoundaryForDropdown($pen, $dropdown);
     },
 
     _fixDropDownPosition: function($dropdown, $pen) {
@@ -103,11 +112,34 @@ define([
       }
     },
 
+    _checkAndSetLeftBoundaryForPen: function($pen) {
+      if (this.leftBoundaryWidth) {
+        if (!this.initialPenLeftPosition) {
+          this.initialPenLeftPosition = $pen.position().left;
+        }
+        if ($pen.offset().left <= this.leftBoundaryWidth) {
+          $pen.css('left', (this.leftBoundaryWidth - $pen.offset().left) + $pen.position().left);
+        }
+        else {
+          $pen.css('left', this.initialPenLeftPosition);
+        }
+      }
+    },
+
+    _checkAndSetLeftBoundaryForDropdown: function($pen, $dropdown) {
+      if (this.leftBoundaryWidth) {
+        if ($pen.offset().left < this.leftBoundaryWidth + this.dropDownMargin) {
+          $dropdown.css('left', $pen.position().left + 1); // +1 to show left shadow of dropdown
+        }
+      }
+    },
+
     _positionPenForShortModules: function() {
       this.$modules.on('mouseenter.stickyPenScroller', function(e) {
         var $module = $(e.currentTarget),
             $pen = $module.find('.js-pen');
 
+        this._checkAndSetLeftBoundaryForPen($pen);
         if ($module.outerHeight() < $pen.outerHeight()) {
           $pen.css('top', this.penTopPosForShortModules);
         }

--- a/test/specs/Component/StickyPenScroller.js
+++ b/test/specs/Component/StickyPenScroller.js
@@ -1,0 +1,39 @@
+define(['jquery', 'Component/StickyPenScroller'], function($, StickyPenScroller) {
+  beforeEach(function() {
+    this.$context = affix('.js-context .js-editable .js-pen+.js-dropdown');
+    this.$context.find('.js-pen').css({
+      position: 'absolute',
+      left: 0,
+    });
+    this.$context.find('.js-dropdown').css({
+      position: 'absolute',
+      left: 0,
+    });
+    this.pen = new StickyPenScroller({
+      $context: this.$context,
+      moduleClass: '.js-editable',
+      leftBoundaryWidth: 70,
+    });
+  });
+
+  afterEach(function() {
+    this.pen.unbind();
+  });
+
+  describe('on hover over module', function() {
+    it('pen is repositioned to left boundary', function() {
+      expect(this.$context.find('.js-pen').offset().left).toBe(0);
+      this.$context.find('.js-editable').mouseenter();
+      expect(this.$context.find('.js-pen').offset().left).toBe(70);
+    });
+  });
+
+  describe('on click on pen', function() {
+    it('dropdown is repositioned to left boundary', function() {
+      expect(this.$context.find('.js-dropdown').offset().left).toBe(0);
+      this.$context.find('.js-editable').mouseenter();
+      this.$context.find('.js-pen').mouseup();
+      expect(this.$context.find('.js-dropdown').offset().left).toBe(71);
+    });
+  });
+});


### PR DESCRIPTION
refs: https://github.com/adobe-community/issues/issues/18554

Goal of this PR: Allow for a new left boundary option which will ensure the menu and pen are always visible and never hidden by the sidebar.