### PR TITLE
Clouduploder: Add default drop active class to the droppable element

### DIFF
--- a/Component/CloudUploader.js
+++ b/Component/CloudUploader.js
@@ -54,6 +54,9 @@ define([
       },
       text: {
         defaultResponseError: ''
+      },
+      dropElementClasses: {
+        dropActive: 'fine-uploader-drop-active',
       }
     },
 
@@ -154,6 +157,7 @@ define([
 
       this._dropZone = new fineUploader.DragAndDrop({
         dropZoneElements: [element],
+        classes: this._config.dropElementClasses,
         callbacks: {
           processingDroppedFiles: function() {
             // TODO: fire an event on the uploader so that, e.g., a spinner can be shown

--- a/test/specs/Component/CloudUploader.js
+++ b/test/specs/Component/CloudUploader.js
@@ -331,6 +331,21 @@ define([
         }));
       });
 
+      it('creates a DragAndDrop instance with the provided classes', function() {
+        var dropElementClasses = {
+          dropActive: 'dropClass',
+        };
+
+        this.uploader = Uploader.init({
+          dropElementClasses: dropElementClasses,
+        });
+
+        this.uploader.setDropElement(document.body);
+        expect(fineUploader.DragAndDrop).toHaveBeenCalledWith(jasmine.objectContaining({
+          classes: dropElementClasses,
+        }));
+      });
+
       it('creates a DragAndDrop instance with the provided callback', function() {
         var processingDoneFn = jasmine.createSpy();
 


### PR DESCRIPTION
Resolves adobe-community/issues/issues/24281